### PR TITLE
Temporary allow to use DENO_IMPORT_MAP env to use deno import maps

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 set -eu
 
-$HELM_PLUGIN_DIR/bin/deno run --unstable --allow-net --allow-read --allow-write --allow-run --allow-env --quiet $HELM_PLUGIN_DIR/bin/bundle.js $@
+# Temporary allow to use DENO_IMPORT_MAP env to use deno import maps
+# TODO: use flag instead
+if [ ! -z "${DENO_IMPORT_MAP:-}" ]; then
+  importmap="--importmap=$DENO_IMPORT_MAP"
+fi
+
+$HELM_PLUGIN_DIR/bin/deno run --unstable --allow-net --allow-read --allow-write --allow-run --allow-env --quiet ${importmap:-} $HELM_PLUGIN_DIR/bin/bundle.js $@


### PR DESCRIPTION
TODO: use flag instead and use import_map only for chart, not the whole process