### PR TITLE
Bundle deno code into 1 file and then use it to render the chart

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -27,6 +27,10 @@ jobs:
         run: |
           helm plugin install https://github.com/jkroepke/helm-secrets --version v3.4.1
 
+      - name: Install helm-push
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push --version v0.9.0
+
       - name: Install plugin
         run: make install-plugin
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ fmt:
 
 # Run fast and independant tests
 test:
-	@ $(shell $(HELM) env) deno test --allow-run --allow-env src/ e2e-tests/
+	@ $(shell $(HELM) env) deno test --unstable --allow-run --allow-read --allow-write --allow-env --allow-net src/ e2e-tests/
 
 # Run all tests
 #
@@ -32,4 +32,4 @@ test:
 # - helm-diff
 # - kubernetes cluster with access to read services in default namespace
 test-all:
-	@ $(shell $(HELM) env) RUN_ALL_TESTS=true deno test --allow-run --allow-env src/ e2e-tests/
+	@ $(shell $(HELM) env) RUN_ALL_TESTS=true deno test --unstable --allow-run --allow-read --allow-write --allow-env --allow-net src/ e2e-tests/

--- a/e2e-tests/charts/prebundled/Chart.yaml
+++ b/e2e-tests/charts/prebundled/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: prebundled
+description: A helm chart for helm-deno testing
+icon: https://raw.githubusercontent.com/twbs/icons/a41f763/icons/pie-chart-fill.svg
+version: 1.0.0

--- a/e2e-tests/charts/prebundled/deno-bundle.js
+++ b/e2e-tests/charts/prebundled/deno-bundle.js
@@ -1,0 +1,15 @@
+// This chart is prebundled and than changed to check that helm-deno will use
+// deno-bundle.js when --deno-use-bundle flag has been provided and
+// deno-templates/index.ts otherwise
+
+export default function prebundled() {
+  return [
+    {
+      kind: "ServiceAccount",
+      apiVersion: "v1",
+      metadata: {
+        name: "prebundled",
+      },
+    },
+  ]
+}

--- a/e2e-tests/charts/prebundled/deno-templates/index.ts
+++ b/e2e-tests/charts/prebundled/deno-templates/index.ts
@@ -1,0 +1,11 @@
+export default function prebundled() {
+  return [
+    {
+      kind: "ServiceAccount",
+      apiVersion: "v1",
+      metadata: {
+        name: "not-bundled",
+      },
+    },
+  ]
+}

--- a/e2e-tests/e2e.test.ts
+++ b/e2e-tests/e2e.test.ts
@@ -37,9 +37,9 @@ async function runHelmDeno(args: string[]) {
   return { status, stdout: toText(output), stderr: toText(error) }
 }
 
-Deno.test(
-  "should successfuly run `helm deno template` with deno chart",
-  async () => {
+Deno.test({
+  name: "should successfuly run `helm deno template` with deno chart",
+  async fn() {
     const chartPath = path.join(chartsBin, "one-service")
 
     const { status, stdout, stderr } = await runHelmDeno([
@@ -73,8 +73,8 @@ Deno.test(
       },
     ])
     assertEquals(status.success, true)
-  }
-)
+  },
+})
 
 Deno.test(
   "should handle error in deno chart during `helm deno template`",
@@ -453,7 +453,7 @@ Deno.test({
 })
 
 Deno.test({
-  name: "should use deno-bundle.js if --deno-use-bundle flag have been passed",
+  name: "should use deno-bundle.js if `--deno-bundle require` have been passed",
   async fn() {
     const chartPath = path.join(chartsBin, "prebundled")
 
@@ -461,7 +461,8 @@ Deno.test({
       "template",
       "my-release-name",
       chartPath,
-      "--deno-use-bundle",
+      "--deno-bundle",
+      "require",
     ])
 
     assertEquals(stderr, "")
@@ -480,7 +481,63 @@ Deno.test({
 
 Deno.test({
   name:
-    "should use deno-templates/index.ts if --deno-use-bundle flag have not been passed",
+    "should use deno-bundle.js if `--deno-bundle prefer` have been passed and deno-bundle.js exists",
+  async fn() {
+    const chartPath = path.join(chartsBin, "prebundled")
+
+    const { status, stdout, stderr } = await runHelmDeno([
+      "template",
+      "my-release-name",
+      chartPath,
+      "--deno-bundle",
+      "prefer",
+    ])
+
+    assertEquals(stderr, "")
+    assertEquals(yaml.parseAll(stdout), [
+      {
+        kind: "ServiceAccount",
+        apiVersion: "v1",
+        metadata: {
+          name: "prebundled",
+        },
+      },
+    ])
+    assertEquals(status.success, true)
+  },
+})
+
+Deno.test({
+  name:
+    "should use deno-templates/index.ts if `--deno-bundle ignore` have been passed",
+  async fn() {
+    const chartPath = path.join(chartsBin, "prebundled")
+
+    const { status, stdout, stderr } = await runHelmDeno([
+      "template",
+      "my-release-name",
+      chartPath,
+      "--deno-bundle",
+      "ignore",
+    ])
+
+    assertEquals(stderr, "")
+    assertEquals(yaml.parseAll(stdout), [
+      {
+        kind: "ServiceAccount",
+        apiVersion: "v1",
+        metadata: {
+          name: "not-bundled",
+        },
+      },
+    ])
+    assertEquals(status.success, true)
+  },
+})
+
+Deno.test({
+  name:
+    "should use deno-templates/index.ts if --deno-bundle have not been passed",
   async fn() {
     const chartPath = path.join(chartsBin, "prebundled")
 

--- a/e2e-tests/e2e.test.ts
+++ b/e2e-tests/e2e.test.ts
@@ -451,3 +451,55 @@ Deno.test({
     }
   },
 })
+
+Deno.test({
+  name: "should use deno-bundle.js if --deno-use-bundle flag have been passed",
+  async fn() {
+    const chartPath = path.join(chartsBin, "prebundled")
+
+    const { status, stdout, stderr } = await runHelmDeno([
+      "template",
+      "my-release-name",
+      chartPath,
+      "--deno-use-bundle",
+    ])
+
+    assertEquals(stderr, "")
+    assertEquals(yaml.parseAll(stdout), [
+      {
+        kind: "ServiceAccount",
+        apiVersion: "v1",
+        metadata: {
+          name: "prebundled",
+        },
+      },
+    ])
+    assertEquals(status.success, true)
+  },
+})
+
+Deno.test({
+  name:
+    "should use deno-templates/index.ts if --deno-use-bundle flag have not been passed",
+  async fn() {
+    const chartPath = path.join(chartsBin, "prebundled")
+
+    const { status, stdout, stderr } = await runHelmDeno([
+      "template",
+      "my-release-name",
+      chartPath,
+    ])
+
+    assertEquals(stderr, "")
+    assertEquals(yaml.parseAll(stdout), [
+      {
+        kind: "ServiceAccount",
+        apiVersion: "v1",
+        metadata: {
+          name: "not-bundled",
+        },
+      },
+    ])
+    assertEquals(status.success, true)
+  },
+})

--- a/src/args/__tests__/parse-args.test.ts
+++ b/src/args/__tests__/parse-args.test.ts
@@ -14,13 +14,14 @@ Deno.test("Should parse --deno-* flags", () => {
     "--deno-keep-tmp-chart",
     "--deno-import-map",
     "test/import_map.json",
-    "--deno-use-bundle",
+    "--deno-bundle",
+    "require",
   ])
 
   assertEquals(options.logLevel, "debug")
   assertEquals(options.keepTmpChart, true)
   assertEquals(options.importMap, "test/import_map.json")
-  assertEquals(options.useBundle, true)
+  assertEquals(options.bundlePolicy, "require")
   assertEquals(helmArgs, [
     "upgrade",
     "--install",

--- a/src/args/__tests__/parse-args.test.ts
+++ b/src/args/__tests__/parse-args.test.ts
@@ -14,11 +14,13 @@ Deno.test("Should parse --deno-* flags", () => {
     "--deno-keep-tmp-chart",
     "--deno-import-map",
     "test/import_map.json",
+    "--deno-use-bundle",
   ])
 
   assertEquals(options.logLevel, "debug")
   assertEquals(options.keepTmpChart, true)
   assertEquals(options.importMap, "test/import_map.json")
+  assertEquals(options.useBundle, true)
   assertEquals(helmArgs, [
     "upgrade",
     "--install",

--- a/src/args/__tests__/parse-helm-args.test.ts
+++ b/src/args/__tests__/parse-helm-args.test.ts
@@ -135,3 +135,25 @@ Deno.test(
     assertEquals(res, expected)
   }
 )
+
+Deno.test(
+  "Should parse helm template args for `helm push ./chart http://localhost:8080`",
+  () => {
+    const res = parseHelmArgs([
+      "push",
+      "./chart",
+      "http://localhost:8080",
+      "--version",
+      "1.0.0",
+    ])
+
+    const expected: ReturnType<typeof parseHelmArgs> = {
+      command: ["push"],
+      releaseName: "",
+      chartLocation: "./chart",
+      options: ["http://localhost:8080", "--version", "1.0.0"],
+    }
+
+    assertEquals(res, expected)
+  }
+)

--- a/src/args/parse-helm-args.ts
+++ b/src/args/parse-helm-args.ts
@@ -10,6 +10,16 @@ export function parseHelmArgs(
 } {
   const restArgs = args.slice()
   const command: string[] = []
+
+  if (restArgs[0] === "push") {
+    return {
+      command: ["push"],
+      releaseName: "",
+      chartLocation: restArgs[1],
+      options: restArgs.slice(2),
+    }
+  }
+
   if (restArgs[0] === "secrets") {
     command.push(restArgs.shift() as string)
   }

--- a/src/args/parse-helm-deno-args.ts
+++ b/src/args/parse-helm-deno-args.ts
@@ -10,6 +10,7 @@ export interface HelmDenoOptions {
   readonly logLevel: LogLevel
   readonly keepTmpChart: boolean
   readonly importMap: string
+  readonly useBundle: boolean
 }
 
 const parser = args
@@ -42,6 +43,12 @@ const parser = args
       describe: "Path to import_map.json",
     })
   )
+  .with(
+    BinaryFlag("deno-use-bundle", {
+      describe:
+        "Use prebundled chart. File <chart>/deno-bundle.js is required for that. deno-bundle.js is automaticly created by `helm deno push`",
+    })
+  )
 
 function toEnum<T>(value: string): T {
   // deno-lint-ignore no-explicit-any
@@ -68,6 +75,7 @@ export function parseArgs(args: readonly string[]): ParseArgsResult {
       logLevel: toEnum(res.value?.["deno-log-level"]) || "info",
       keepTmpChart: !!res.value?.["deno-keep-tmp-chart"],
       importMap: res.value?.["deno-import-map"],
+      useBundle: !!res.value?.["deno-keep-tmp-chart"],
     },
     helmArgs: res.remaining().rawArgs(),
   }

--- a/src/args/parse-helm-deno-args.ts
+++ b/src/args/parse-helm-deno-args.ts
@@ -75,7 +75,7 @@ export function parseArgs(args: readonly string[]): ParseArgsResult {
       logLevel: toEnum(res.value?.["deno-log-level"]) || "info",
       keepTmpChart: !!res.value?.["deno-keep-tmp-chart"],
       importMap: res.value?.["deno-import-map"],
-      useBundle: !!res.value?.["deno-keep-tmp-chart"],
+      useBundle: !!res.value?.["deno-use-bundle"],
     },
     helmArgs: res.remaining().rawArgs(),
   }

--- a/src/args/parse-helm-fetch-args.ts
+++ b/src/args/parse-helm-fetch-args.ts
@@ -5,7 +5,7 @@ import {
 } from "https://deno.land/x/args@2.0.7/flag-types.ts"
 import { Text } from "https://deno.land/x/args@2.0.7/value-types.ts"
 
-const textOption = (flag: string, alias?: readonly string[]) =>
+const textOption = (flag: string) =>
   PartialOption(flag, {
     type: Text,
     default: "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ async function main() {
       await bundleChart(chartLocation, options)
       await helmExecute(["push", chartLocation, ...helmRestArgs])
     } finally {
-      await cleanupBundle(chartLocation, options)
+      await cleanupBundle(chartLocation)
     }
     return
   }


### PR DESCRIPTION
1. Bundle all deno code into <chart>/deno-bundle.js during `helm deno push`
2. Use bundle instead of deno-templates/index.ts during `helm template/upgrade/install` by providing flag `--deno-bundle=require/prefer/ignore` (default `ignore`)

This feature is required for people who use import maps and what to push their charts to registry