### PR TITLE
Fix support of helm-secrets plugin

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -13,6 +13,12 @@ jobs:
         with:
           deno-version: v1.8.x
 
+      - name: Install Age Encryption Tool
+        run: |
+          wget https://github.com/FiloSottile/age/releases/download/v1.0.0-rc.1/age-v1.0.0-rc.1-linux-amd64.tar.gz -O age.tar.gz
+          tar xvf age.tar.gz age/age age/age-keygen
+          echo "$PWD/age" >> $GITHUB_PATH
+
       - name: Install helm-diff
         run: |
           helm plugin install https://github.com/databus23/helm-diff --version v3.1.3

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -19,6 +19,11 @@ jobs:
           tar xvf age.tar.gz age/age age/age-keygen
           echo "$PWD/age" >> $GITHUB_PATH
 
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@55d09a81cc2b0b5235af697e3b84b1f502f63025 # v1 at 14 April 2020
+        with:
+          version: 3.7.1
+
       - name: Install helm-diff
         run: |
           helm plugin install https://github.com/databus23/helm-diff --version v3.1.3

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -11,13 +11,7 @@ jobs:
 
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.4.x
-
-      - name: Install helm 3
-        run: |
-          wget https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz -O helm.tar.gz
-          tar xvf helm.tar.gz linux-amd64/helm
-          echo "$PWD/linux-amd64" >> $GITHUB_PATH
+          deno-version: v1.8.x
 
       - name: Install helm-diff
         run: |
@@ -25,7 +19,7 @@ jobs:
 
       - name: Install helm-secrets
         run: |
-          helm plugin install https://github.com/jkroepke/helm-secrets --version v3.4.1
+          helm plugin install https://github.com/jkroepke/helm-secrets --version v3.6.1
 
       - name: Install helm-push
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,7 @@ jobs:
 
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.4.x
-
-      - name: Install helm 3
-        run: |
-          wget https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz -O helm.tar.gz
-          tar xvf helm.tar.gz linux-amd64/helm
-          echo "$PWD/linux-amd64" >> $GITHUB_PATH
+          deno-version: v1.8.x
 
       - name: Install plugin
         run: make install-plugin

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ test:
 # Run all tests
 #
 # Require
-# - helm-secrets
-# - helm-diff
-# - kubernetes cluster with access to read services in default namespace
+# - https://github.com/jkroepke/helm-secrets
+# - https://github.com/mozilla/sops
+# - https://github.com/FiloSottile/age
+# - https://github.com/jkroepke/helm-secrets
+# - Docker
+# - Kubernetes cluster with access to read services in default namespace
 test-all:
 	@ $(shell $(HELM) env) RUN_ALL_TESTS=true deno test --unstable --allow-run --allow-read --allow-write --allow-env --allow-net src/ e2e-tests/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install-tools:
 	@ yarn --frozen-lockfile
 
 install-plugin:
-	@ HELM_PLUGIN_DIR="$$PWD" ./scripts/install.sh v1.4.6
+	@ HELM_PLUGIN_DIR="$$PWD" ./scripts/install.sh v1.8.3
 
 lint:
 	@ yarn prettier --check .

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ test:
 # - Kubernetes cluster with access to read services in default namespace
 test-all:
 	@ $(shell $(HELM) env) RUN_ALL_TESTS=true deno test --unstable --allow-run --allow-read --allow-write --allow-env --allow-net src/ e2e-tests/
+
+update-deps:
+	@ # Install udd: https://github.com/hayd/deno-udd
+	udd src/**/*.ts

--- a/e2e-tests/e2e.test.ts
+++ b/e2e-tests/e2e.test.ts
@@ -1,11 +1,11 @@
 import { getAvailablePort } from "https://deno.land/x/port@1.0.0/mod.ts"
-import * as fs from "https://deno.land/std@0.86.0/fs/mod.ts"
-import * as path from "https://deno.land/std@0.86.0/path/mod.ts"
-import * as yaml from "https://deno.land/std@0.86.0/encoding/yaml.ts"
+import * as fs from "https://deno.land/std@0.93.0/fs/mod.ts"
+import * as path from "https://deno.land/std@0.93.0/path/mod.ts"
+import * as yaml from "https://deno.land/std@0.93.0/encoding/yaml.ts"
 import {
   assertEquals,
   assertStringIncludes,
-} from "https://deno.land/std@0.86.0/testing/asserts.ts"
+} from "https://deno.land/std@0.93.0/testing/asserts.ts"
 import { ignoreNotFoundError } from "../src/utils/ignore-not-found-error.ts"
 
 const runAllTests = Deno.env.get("RUN_ALL_TESTS") === "true"

--- a/e2e-tests/e2e.test.ts
+++ b/e2e-tests/e2e.test.ts
@@ -389,8 +389,9 @@ async function startHelmRegistry() {
     "--detach",
     `--publish=${port}:8080`,
     "--env=STORAGE=local",
-    "--env=STORAGE_LOCAL_ROOTDIR=/home/chartmuseum/charts",
-    "chartmuseum/chartmuseum:v0.12.0@sha256:38c5ec3b30046d7a02a55b4c8bd8a0cd279538c2e36090973798a858e900b18e",
+    "--env=STORAGE_LOCAL_ROOTDIR=/charts",
+    "--user=0", // To have write permission to /charts
+    "ghcr.io/helm/chartmuseum:v0.13.1@sha256:79350ffbf8b0c205cf8b45988de899db594618b24fefd17cdbcdbbc8eb795d72",
   ])
 
   if (!status.success) {
@@ -604,7 +605,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "should throw error if`--deno-bundle require` have been passed but deno-bundle.js do not exist",
+    "should throw error if `--deno-bundle require` have been passed but deno-bundle.js do not exist",
   async fn() {
     const chartPath = path.join(chartsBin, "one-service")
 

--- a/e2e-tests/e2e.test.ts
+++ b/e2e-tests/e2e.test.ts
@@ -495,6 +495,36 @@ Deno.test({
 })
 
 Deno.test({
+  name: "should clean deno-bundle.js if push wasn't successful",
+  ignore: !runAllTests,
+  async fn() {
+    const chartPath = path.join(chartsBin, "one-service")
+    const denoBundlePath = path.join(chartPath, "deno-bundle.js")
+
+    try {
+      const { status } = await runHelmDeno([
+        "push",
+        chartPath,
+        "http://127.0.0.1:1",
+      ])
+
+      if (status.success) {
+        assertEquals(status.success, false, "should not successfully push")
+      }
+
+      const isDenoBundleExists = await fs.exists(denoBundlePath)
+      assertEquals(
+        isDenoBundleExists,
+        false,
+        "should not have left temporary file deno-bundle.js"
+      )
+    } finally {
+      await removeIfExists(denoBundlePath)
+    }
+  },
+})
+
+Deno.test({
   name: "should use deno-bundle.js if `--deno-bundle require` have been passed",
   async fn() {
     const chartPath = path.join(chartsBin, "prebundled")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,6 @@ description: |-
   This plugin provides Deno for Helm charts
 useTunnel: false
 hooks:
-  install: "$HELM_PLUGIN_DIR/scripts/install.sh v1.4.6"
-  update: "$HELM_PLUGIN_DIR/scripts/install.sh v1.4.6"
+  install: "$HELM_PLUGIN_DIR/scripts/install.sh v1.8.3"
+  update: "$HELM_PLUGIN_DIR/scripts/install.sh v1.8.3"
 command: "$HELM_PLUGIN_DIR/scripts/run.sh"

--- a/src/args/__tests__/parse-args.test.ts
+++ b/src/args/__tests__/parse-args.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts"
 import { parseArgs } from "../parse-helm-deno-args.ts"
 
 Deno.test("Should parse --deno-* flags", () => {

--- a/src/args/__tests__/parse-helm-args.test.ts
+++ b/src/args/__tests__/parse-helm-args.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts"
 import { parseHelmArgs } from "../parse-helm-args.ts"
 
 Deno.test("Should parse helm template args for `helm upgrade`", () => {

--- a/src/args/__tests__/parse-helm-fetch-args.test.ts
+++ b/src/args/__tests__/parse-helm-fetch-args.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts"
 import { parseHelmFetchArgs } from "../parse-helm-fetch-args.ts"
 
 Deno.test("Should parse helm fetch args", () => {

--- a/src/args/__tests__/parse-helm-template-args.test.ts
+++ b/src/args/__tests__/parse-helm-template-args.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.86.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts"
 import { parseHelmTemplateArgs } from "../parse-helm-template-args.ts"
 
 Deno.test("Should parse helm template args", () => {

--- a/src/args/parse-helm-deno-args.ts
+++ b/src/args/parse-helm-deno-args.ts
@@ -1,9 +1,9 @@
-import args from "https://deno.land/x/args@2.0.7/wrapper.ts"
+import args from "https://deno.land/x/args@2.1.0/wrapper.ts"
 import {
   PartialOption,
   BinaryFlag,
-} from "https://deno.land/x/args@2.0.7/flag-types.ts"
-import { Choice, Text } from "https://deno.land/x/args@2.0.7/value-types.ts"
+} from "https://deno.land/x/args@2.1.0/flag-types.ts"
+import { Choice, Text } from "https://deno.land/x/args@2.1.0/value-types.ts"
 
 type LogLevel = "info" | "debug"
 

--- a/src/args/parse-helm-fetch-args.ts
+++ b/src/args/parse-helm-fetch-args.ts
@@ -1,9 +1,9 @@
-import args from "https://deno.land/x/args@2.0.7/wrapper.ts"
+import args from "https://deno.land/x/args@2.1.0/wrapper.ts"
 import {
   PartialOption,
   BinaryFlag,
-} from "https://deno.land/x/args@2.0.7/flag-types.ts"
-import { Text } from "https://deno.land/x/args@2.0.7/value-types.ts"
+} from "https://deno.land/x/args@2.1.0/flag-types.ts"
+import { Text } from "https://deno.land/x/args@2.1.0/value-types.ts"
 
 const textOption = (flag: string) =>
   PartialOption(flag, {

--- a/src/args/parse-helm-template-args.ts
+++ b/src/args/parse-helm-template-args.ts
@@ -1,6 +1,6 @@
-import args from "https://deno.land/x/args@2.0.7/wrapper.ts"
-import { CollectOption } from "https://deno.land/x/args@2.0.7/flag-types.ts"
-import { Text } from "https://deno.land/x/args@2.0.7/value-types.ts"
+import args from "https://deno.land/x/args@2.1.0/wrapper.ts"
+import { CollectOption } from "https://deno.land/x/args@2.1.0/flag-types.ts"
+import { Text } from "https://deno.land/x/args@2.1.0/value-types.ts"
 
 const textOption = (flag: string, alias?: readonly string[]) =>
   CollectOption(flag, {

--- a/src/deno/render-chart.ts
+++ b/src/deno/render-chart.ts
@@ -1,8 +1,8 @@
 import type { ChartContext } from "../std/mod.ts"
 import type { HelmDenoOptions } from "../args/parse-helm-deno-args.ts"
-import * as yaml from "https://deno.land/std@0.86.0/encoding/yaml.ts"
-import * as fs from "https://deno.land/std@0.86.0/fs/mod.ts"
-import * as path from "https://deno.land/std@0.86.0/path/mod.ts"
+import * as yaml from "https://deno.land/std@0.93.0/encoding/yaml.ts"
+import * as fs from "https://deno.land/std@0.93.0/fs/mod.ts"
+import * as path from "https://deno.land/std@0.93.0/path/mod.ts"
 import { ignoreNotFoundError } from "../utils/ignore-not-found-error.ts"
 
 // deno-lint-ignore no-explicit-any

--- a/src/helm/execute.ts
+++ b/src/helm/execute.ts
@@ -1,4 +1,7 @@
-export async function helmExecute(args: readonly string[]): Promise<void> {
+export async function helmExecute(
+  args: readonly string[],
+  { autoExitOnError = false }: { autoExitOnError?: boolean } = {}
+): Promise<{ exitCode?: number }> {
   const helm = Deno.env.get("HELM_BIN") as string
   const cmd = Deno.run({
     cmd: [helm, ...args],
@@ -8,6 +11,11 @@ export async function helmExecute(args: readonly string[]): Promise<void> {
 
   const status = await cmd.status()
   if (!status.success) {
-    Deno.exit(status.code)
+    if (autoExitOnError) {
+      Deno.exit(status.code)
+    }
+    return { exitCode: status.code }
   }
+
+  return {}
 }

--- a/src/helm/fetch.ts
+++ b/src/helm/fetch.ts
@@ -1,5 +1,5 @@
-import * as fs from "https://deno.land/std@0.86.0/fs/mod.ts"
-import * as path from "https://deno.land/std@0.86.0/path/mod.ts"
+import * as fs from "https://deno.land/std@0.93.0/fs/mod.ts"
+import * as path from "https://deno.land/std@0.93.0/path/mod.ts"
 import { parseHelmFetchArgs } from "../args/parse-helm-fetch-args.ts"
 import { withErrorMsg } from "../std/mod.ts"
 

--- a/src/helm/get-chart-context.ts
+++ b/src/helm/get-chart-context.ts
@@ -36,6 +36,7 @@ export async function getChartContext(
   release: string,
   tmpDir: string,
   chartDir: string,
+  commands: readonly string[],
   args: readonly string[]
 ): Promise<ChartContext> {
   const getValuesChartDir = path.join(tmpDir, "get-values-chart")
@@ -63,6 +64,7 @@ export async function getChartContext(
     const cmd = Deno.run({
       cmd: [
         helm,
+        ...(commands.includes("secrets") ? ["secrets"] : []),
         "template",
         release,
         getValuesChartDir,

--- a/src/helm/get-chart-context.ts
+++ b/src/helm/get-chart-context.ts
@@ -1,7 +1,7 @@
 import type { ChartContext, Release } from "../std/mod.ts"
-import * as fs from "https://deno.land/std@0.86.0/fs/mod.ts"
-import * as path from "https://deno.land/std@0.86.0/path/mod.ts"
-import * as yaml from "https://deno.land/std@0.86.0/encoding/yaml.ts"
+import * as fs from "https://deno.land/std@0.93.0/fs/mod.ts"
+import * as path from "https://deno.land/std@0.93.0/path/mod.ts"
+import * as yaml from "https://deno.land/std@0.93.0/encoding/yaml.ts"
 import { parseHelmTemplateArgs } from "../args/parse-helm-template-args.ts"
 import { ignoreNotFoundError } from "../utils/ignore-not-found-error.ts"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ async function main() {
       releaseName,
       tmpDir,
       tmpChartPath,
+      command,
       args
     )
     debug(`Chart context:\n${JSON.stringify(chartContext, null, 2)}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file
-import * as fs from "https://deno.land/std@0.86.0/fs/mod.ts"
-import * as path from "https://deno.land/std@0.86.0/path/mod.ts"
+import * as fs from "https://deno.land/std@0.93.0/fs/mod.ts"
+import * as path from "https://deno.land/std@0.93.0/path/mod.ts"
 import { parseHelmArgs, supportedCommands } from "./args/parse-helm-args.ts"
 import { parseArgs } from "./args/parse-helm-deno-args.ts"
 import {


### PR DESCRIPTION
Currently, the secrets in the chart values are not decrypted, but are transmitted as is, since helm-secrets is not used when preparing values